### PR TITLE
Develop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(cmaker
     cmaker/add_thirdparty_library.cpp
     cmaker/add_submodule.cpp
     cmaker/functions.cpp
+    cmaker/writer_funcs.cpp
     )
 
 # Set include dirs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,31 @@
 cmake_minimum_required(VERSION 3.16)
 
 project(cmaker LANGUAGES CXX C)
-set(CMAKE_CXX_STANDARD 17)
+include(CheckCXXCompilerFlag)
+check_cxx_compiler_flag("-std=c++17" CXX17_SUPPORTED)
+if(NOT CXX17_SUPPORTED)
+    message(WARNING "C++17 is not supported by the compiler")
+    set(CMAKE_CXX_STANDARD 11)
+    add_compile_definitions("USE_BOOST_FILESYSTEM")
+else()
+    message(STATUS "Using C++17's <filesystem>")
+    set(CMAKE_CXX_STANDARD 17)
+endif()
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_STANDARD_EXTENSION OFF)
+
 add_compile_options(-Wfatal-errors)
 
 # Enable extra find_package modules
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake_modules)
 
 # Find the library
-find_package(Boost REQUIRED COMPONENTS program_options system filesystem)
+if (NOT CXX17_SUPPORTED)
+    find_package(Boost REQUIRED COMPONENTS program_options filesystem)
+else()
+    find_package(Boost REQUIRED COMPONENTS program_options)
+endif()
+
 find_package(fmt REQUIRED)
 find_package(Threads REQUIRED)
 
@@ -40,7 +55,16 @@ target_include_directories(cmaker
 target_compile_definitions(cmaker PRIVATE "FMT_HEADER_ONLY")
 
 # Link to thirdparty libraries
-target_link_libraries(${PROJECT_NAME} PRIVATE Boost::program_options)
+if (NOT CXX17_SUPPORTED)
+    target_link_libraries(${PROJECT_NAME}
+        PRIVATE
+            Boost::program_options
+            Boost::filesystem)
+else()
+    target_link_libraries(${PROJECT_NAME}
+        PRIVATE
+            Boost::program_options)
+endif()
 
 include(GNUInstallDirs)
 # Set up the installation 
@@ -65,7 +89,7 @@ set(CMAKER_VER_MINOR ${CMAKE_MATCH_1})
 string(REGEX MATCH "#define CMAKER_VERSION_PATCH ([0-9]*)" _ ${HEADER_CONTENTS})
 set(CMAKER_VER_PATCH ${CMAKE_MATCH_1})
 
-message(STATUS "current myexe version: ${CMAKER_VER_MAJOR}.${CMAKER_VER_MINOR}.${CMAKER_VER_PATCH}")
+message(STATUS "current CMaker version: ${CMAKER_VER_MAJOR}.${CMAKER_VER_MINOR}.${CMAKER_VER_PATCH}")
 set(CPACK_PACKAGE_VERSION_MAJOR ${CMAKER_VER_MAJOR})
 set(CPACK_PACKAGE_VERSION_MINOR ${CMAKER_VER_MINOR})
 set(CPACK_PACKAGE_VERSION_PATCH ${CMAKER_VER_PATCH})

--- a/README.md
+++ b/README.md
@@ -29,17 +29,20 @@ mylib
 │   ├── bench_example.cpp
 │   └── CMakeLists.txt
 ├── CMakeLists.txt
+├── README.md
+├── LICENSE
+├── .gitignore
+├── .clang-format
 ├── cmake_modules
 ├── mylib
-│   └── header.h
-├── src
-│   └── library.cpp
+│   ├── mylib.h.in
+│   └── mylib.cpp
 ├── thirdparty
 └── unit_test
     ├── CMakeLists.txt
     └── example.cpp
 
-6 directories, 7 files
+5 directories, 9 files
 ```
 
 1. a `bench` directory for benchmarking, with pre-configured CMakeLists.txt and a sample benchmark source file.
@@ -80,9 +83,10 @@ It also contains pre-configured `.gitignore`, `.clang-format` and `.clang-tidy` 
 - [Git](https://git-scm.com/downloads)
 - [GTest](https://github.com/google/googletest)
 - [Benchmark](https://github.com/google/benchmark)
-- A C++ compiler that supports C++17, like GCC 9.3 or above (requried for std::filesystem and initializer for-loop)
+- A C++ compiler that supports C++11 (17), like GCC 4.8.5 (7.3.0) or above (requried for std::filesystem and initializer for-loop)
 
-The project is tested on Ubuntu 20.04 with GCC 13.2.0, and since it uses only standard C++17 features and well known cross-platform libraries, it should work on other platforms as well.
+The project is tested on rhel 7.9 with GCC 4.8.5 and ubuntu 20.04 with GCC 13.2.0.
+If your compiler does not support C++17, Boost.filesystem is required.
 
 ## Installation
 

--- a/cmaker/add_submodule.cpp
+++ b/cmaker/add_submodule.cpp
@@ -11,19 +11,19 @@ void AddSubmodule()
 {
     if (!IsProjectRoot())
     {
-        ERROR("must be under the project root directory!");
+        LOGERR("must be under the project root directory!");
     }
 
     if (!vm.count("name"))
     {
-        WARN("submodule name is required!");
+        LOGWARN("submodule name is required!");
         PrintUsageAndQuit(adder_module);
     }
 
     name = vm["name"].as<std::string>();
     if (!vm.count("url"))
     {
-        WARN("url is required to init submodule!");
+        LOGWARN("url is required to init submodule!");
         PrintUsageAndQuit(adder_module);
     }
     std::string url = vm["url"].as<std::string>();
@@ -31,14 +31,14 @@ void AddSubmodule()
 
     if (!IsUnderCurrentDirectory(module_dir))
     {
-        ERROR("submodule dir {{{}}} is not under current working directory {{{}}}", module_dir,
+        LOGERR("submodule dir {{{}}} is not under current working directory {{{}}}", module_dir,
             fs::current_path().string());
     }
 
     auto target_path = fs::path(module_dir) / name;
     if (fs::exists(target_path) && !fs::is_empty(target_path))
     {
-        ERROR("the target path {{{}}} for submodule to be initialized exists and not empty!!",
+        LOGERR("the target path {{{}}} for submodule to be initialized exists and not empty!!",
             target_path.string());
     }
 
@@ -46,10 +46,10 @@ void AddSubmodule()
     int result = bp::system(command);
     if (0 != result)
     {
-        ERROR("submodule initialize error! ec:{}, reason:{}", result, strerror(result));
+        LOGERR("submodule initialize error! ec:{}, reason:{}", result, strerror(result));
     }
 
-    INFO("submodule initialized in {}", fs::canonical(target_path).string());
-    INFO("please insert 'add_subdirectory({})' to add dependency", target_path.string());
-    INFO("or call 'cmaker add-library ...' to add dependency");
+    LOGINFO("submodule initialized in {}", fs::canonical(target_path).string());
+    LOGINFO("please insert 'add_subdirectory({})' to add dependency", target_path.string());
+    LOGINFO("or call 'cmaker add-library ...' to add dependency");
 }

--- a/cmaker/add_thirdparty_library.cpp
+++ b/cmaker/add_thirdparty_library.cpp
@@ -15,8 +15,7 @@ void AddThirdpartyLibrary()
 {
     if (!vm.count("name"))
     {
-        WARN("missing library name for creating project!");
-        PrintUsageAndQuit(adder_library);
+        ERROR("missing library name for creating project!");
     }
     name = vm["name"].as<std::string>();
 

--- a/cmaker/add_thirdparty_library.cpp
+++ b/cmaker/add_thirdparty_library.cpp
@@ -15,18 +15,18 @@ void AddThirdpartyLibrary()
 {
     if (!vm.count("name"))
     {
-        ERROR("missing library name for creating project!");
+        LOGERR("missing library name for creating project!");
     }
     name = vm["name"].as<std::string>();
 
     if (!vm.count("inc"))
     {
-        WARN("header path is required");
+        LOGWARN("header path is required");
         PrintUsageAndQuit(adder_library);
     }
     if (!vm.count("path"))
     {
-        WARN("library path is required\n");
+        LOGWARN("library path is required\n");
         PrintUsageAndQuit(adder_library);
     }
 
@@ -35,31 +35,31 @@ void AddThirdpartyLibrary()
     fs::path header_file = inc_path.filename();
     if (header_file.empty())
     {
-        ERROR("include hint: {} does not have header file", inc_path.string());
+        LOGERR("include hint: {} does not have header file", inc_path.string());
     }
     inc_names = header_file.string();
 
     inc_hints = inc_path.parent_path();
-    INFO("given header path: {}", inc_hints.string());
+    LOGINFO("given header path: {}", inc_hints.string());
 
     if (!fs::exists(inc_path) || !fs::is_regular_file(inc_path))
     {
-        WARN("header file {{}} does not exist!", header_file.string());
+        LOGWARN("header file {{}} does not exist!", header_file.string());
     }
 
     if (!fs::exists(inc_hints) || !fs::is_directory(inc_hints))
     {
-        WARN("header include dir {{}} does not exist!", inc_hints.string());
+        LOGWARN("header include dir {{}} does not exist!", inc_hints.string());
     }
 
     lib_path = fs::canonical(vm["path"].as<std::string>());
     if (!fs::exists(lib_path) || !fs::is_directory(lib_path))
     {
-        WARN("library path {{}} does not exsit!", lib_path.string());
+        LOGWARN("library path {{}} does not exsit!", lib_path.string());
     }
 
     WriteCMakeFindModule();
-    INFO("successfully added library: {}, inc-path:{}, lib-path:{}", name, inc_hints.string(),
+    LOGINFO("successfully added library: {}, inc-path:{}, lib-path:{}", name, inc_hints.string(),
         lib_path.string());
 }
 
@@ -67,12 +67,12 @@ void WriteCMakeFindModule()
 {
     if (!IsProjectRoot())
     {
-        ERROR("must be under the project root directory!");
+        LOGERR("must be under the project root directory!");
     }
 
     if (!fs::exists("cmake_modules") || !fs::is_directory("cmake_modules"))
     {
-        ERROR("cmake_modules directory does not exist!");
+        LOGERR("cmake_modules directory does not exist!");
     }
     // for example, a library name 'libboost_program_options.so'
     // the target name when add-library should be 'boost_program_options'
@@ -84,10 +84,10 @@ void WriteCMakeFindModule()
         fs::current_path() / "cmake_modules" / fmt::format("Find{}.cmake", pascal_name);
     if (fs::exists(module_path))
     {
-        WARN("{} exists, overwrite? (N/y)", module_path.string());
+        LOGWARN("{} exists, overwrite? (N/y)", module_path.string());
         if (!PromptUserConfirm())
         {
-            INFO("abort, please clean up your workspace and retry.");
+            LOGINFO("abort, please clean up your workspace and retry.");
             exit(1);
         }
     }
@@ -95,7 +95,7 @@ void WriteCMakeFindModule()
     std::ofstream module_file(module_path);
     if (!module_file)
     {
-        ERROR("{} open fail, abort!");
+        LOGERR("{} open fail, abort!");
     }
     // AbcDefGhi -> ABCDEFGHI
     std::string upper_pascal = ToUpper(pascal_name);
@@ -129,5 +129,5 @@ endif()
 )==",
         pascal_name, upper_pascal, lib_path.string(), inc_names, inc_hints.string(), name);
 
-    INFO("module_file: {} created.", module_path.string());
+    LOGINFO("module_file: {} created.", module_path.string());
 }

--- a/cmaker/create_new_project.cpp
+++ b/cmaker/create_new_project.cpp
@@ -1,345 +1,57 @@
 #include "functions.h"
+#include "writer_funcs.h"
 
 extern po::options_description creator;
 extern po::variables_map vm;
 
-enum class RepoType
-{
-    STATIC,
-    SHARED,
-    EXECUTABLE,
-};
-
-static RepoType repo_type = RepoType::STATIC;
-static std::string repo_name = "undefined";
-static std::string upper_name;
-
-static void CreateRepoDirs();
-static void WriteCMakeLists();
-static void WriteUnitTests();
-static void WriteBenchmark();
-static void WriteSrcAndHeader();
-
 void CreateNewProject()
 {
+    WriterContext ctx;
     if (!vm.count("name"))
     {
-        ERROR("missing repo name for creating project");
+        LOGERR("missing repo name for creating project");
         PrintUsageAndQuit(creator);
     }
-    repo_name = vm["name"].as<std::string>();
+    ctx.repo_name = vm["name"].as<std::string>();
     if (vm.count("shared"))
     {
-        INFO("creating repo for shared library: {}", repo_name);
-        repo_type = RepoType::SHARED;
+        LOGINFO("creating repo for shared library: {}", ctx.repo_name);
+        ctx.repo_type = RepoType::SHARED;
     }
     else if (vm.count("exe"))
     {
-        INFO("creating repo for executable: {}", repo_name);
-        repo_type = RepoType::EXECUTABLE;
+        LOGINFO("creating repo for executable: {}", ctx.repo_name);
+        ctx.repo_type = RepoType::EXECUTABLE;
     }
     else
     {
-        INFO("creating repo for static library: {}", repo_name);
+        LOGINFO("creating repo for static library: {}", ctx.repo_name);
     }
 
-    CreateRepoDirs();
-}
-
-void CreateRepoDirs()
-{
-    if (!CreateDirIfNotExist(repo_name))
+    if (!CreateDirIfNotExist(ctx.repo_name))
     {
-        ERROR("abort!");
+        LOGERR("abort!");
         exit(1);
     }
 
     // with chdir to
     {
-        PushD _(repo_name);
+        PushD _(ctx.repo_name);
 
-        CreateDirIfNotExist("src");
-        CreateDirIfNotExist(repo_name);
+        CreateDirIfNotExist(ctx.repo_name);
         CreateDirIfNotExist("cmake_modules");
         CreateDirIfNotExist("thirdparty");
         CreateDirIfNotExist("bench");
         CreateDirIfNotExist("unit_test");
-        WriteCMakeLists();
-        WriteUnitTests();
-        WriteBenchmark();
-        WriteSrcAndHeader();
+        WriteCMakeLists(ctx);
+        WriteUnitTests(ctx);
+        WriteBenchmark(ctx);
+        WriteSrcAndHeader(ctx);
+        WriteGitignore();
+        WriteClangformat();
+        WriteLicense(ctx);
+        WriteReadme(ctx);
 
         std::system("git init");
     }
-    // and back to orgin cwd
-}
-
-void WriteCMakeLists()
-{
-    upper_name = ToUpper(repo_name);
-    std::ofstream cmakelist("CMakeLists.txt");
-    cmakelist << "cmake_minimum_required(VERSION 3.21)\n\n"
-              << "project(" << repo_name << " LANGUAGES CXX C)\n\n";
-    cmakelist << "# edit the following settings as you desire\n"
-              << "set(CMAKE_CXX_STANDARD 17)\n"
-              << "set(CMAKE_CXX_STANDARD_REQUIRED ON)\n"
-              << "set(CMAKE_CXX_STANDARD_EXTENSION OFF)\n"
-              << "add_compile_options(-Wfatal-errors)\n\n";
-    cmakelist << "# edit the following line to add your cmake modules\n"
-              << "list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake_modules)\n";
-    cmakelist << "# options flags to turn on/off unit tests and benchmarks\n"
-              << "option(BUILD_TESTS \"build unit tests\" OFF)\n"
-              << "option(BUILD_BENCHMARKS \"build benchmark tests\" OFF)\n";
-    cmakelist << "# edit the following line to add your dependencies\n"
-              << "find_package(Threads REQUIRED)\n\n";
-    // for executable repo, scan the 'repo_name' dir to add all cpp files as it's SRCS
-    if (RepoType::EXECUTABLE == repo_type)
-    {
-        cmakelist << fmt::format("file(GLOB EXECUTABLE_SRC \"{}/*.cpp\")\n", repo_name)
-                  << "add_executable(${PROJECT_NAME} ${EXECUTABLE_SRC})\n";
-        cmakelist << "target_include_directories(${PROJECT_NAME} PRIVATE\n    "
-                  << fmt::format("${{PROJECT_SOURCE_DIR}}/{})\n\n", repo_name);
-    }
-    else // for library repo, scan the 'src' dir to add all cpp files as it's SRCS
-    {
-        cmakelist << "file(GLOB LIBRARY_SRC \"src/*.cpp\")\n"
-                  << "add_library(${PROJECT_NAME} "
-                  << (repo_type == RepoType::SHARED ? "SHARED" : "STATIC")
-                  << " \"${LIBRARY_SRC}\")\n";
-        cmakelist << "# you may add more dependencies' header dir here\n";
-        cmakelist << "target_include_directories(${PROJECT_NAME}\n"
-                  << "    PUBLIC\n"
-                  << "        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/" << repo_name << ">\n"
-                  << "        $<INSTALL_INTERFACE:" << repo_name << ">\n"
-                  << "    PRIVATE\n"
-                  << "        ${PROJECT_SOURCE_DIR}/src)\n\n";
-    }
-
-    // link example
-    cmakelist << "# edit the following line to link your dependencies libraries\n"
-              << "target_link_libraries(${PROJECT_NAME} PRIVATE Threads::Threads)\n\n";
-
-    // unit tests
-    cmakelist << "#if called with -DBUILD_TESTS the unit test targets will be enabled\n";
-    cmakelist << "if(BUILD_TESTS)\n"
-              << "    find_package(GTest REQUIRED)\n"
-              << "    enable_testing()\n"
-              << "    add_subdirectory(unit_test)\nendif()\n\n";
-
-    // benchmark tests
-    cmakelist << "#if called with -DBUILD_BENCHMARKS the benchmark target will be enabled\n";
-    cmakelist << "if(BUILD_BENCHMARKS)\n"
-              << "    find_package(benchmark REQUIRED)\n"
-              << "    add_subdirectory(bench)\nendif()\n\n";
-
-    // install
-    cmakelist << "# install settings\n";
-    cmakelist << "include(GNUInstallDirs)\n"
-              << "install(TARGETS ${PROJECT_NAME}\n"
-              << "    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}\n"
-              << "    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}\n"
-              << "    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}\n)\n";
-    // install public headers if it's library repo
-    if (RepoType::EXECUTABLE != repo_type)
-    {
-        cmakelist << "# install public headers\n";
-        cmakelist << "set(PUBLIC_HEADER_DIR ${PROJECT_SOURCE_DIR}/" << repo_name << ")\n"
-                  << "install(DIRECTORY ${PUBLIC_HEADER_DIR}\n"
-                  << "    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}\n"
-                  << "    FILES_MATCHING\n"
-                  << "        PATTERN \"*.h\"\n"
-                  << "        PATTERN \"*.hpp\"\n)\n";
-    }
-    // both library and executable repo support versioning
-    cmakelist << "# auto versioning reads from header.h to get versionstring\n";
-    cmakelist << fmt::format(R"=(file(STRINGS ${{PROJECT_SOURCE_DIR}}/{0}/header.h
-    HEADER_CONTENTS REGEX "#define {1}_VERSION_.*")
-string(REGEX MATCH "#define {1}_VERSION_MAJOR ([0-9]*)" _ ${{HEADER_CONTENTS}})
-set({1}_VER_MAJOR ${{CMAKE_MATCH_1}})
-string(REGEX MATCH "#define {1}_VERSION_MINOR ([0-9]*)" _ ${{HEADER_CONTENTS}})
-set({1}_VER_MINOR ${{CMAKE_MATCH_1}})
-string(REGEX MATCH "#define {1}_VERSION_PATCH ([0-9]*)" _ ${{HEADER_CONTENTS}})
-set({1}_VER_PATCH ${{CMAKE_MATCH_1}})
-
-message(STATUS "current {0} version: ${{{1}_VER_MAJOR}}.${{{1}_VER_MINOR}}.${{{1}_VER_PATCH}}")
-set(CPACK_PACKAGE_VERSION_MAJOR ${{{1}_VER_MAJOR}})
-set(CPACK_PACKAGE_VERSION_MINOR ${{{1}_VER_MINOR}})
-set(CPACK_PACKAGE_VERSION_PATCH ${{{1}_VER_PATCH}})
-)=",
-        repo_name, upper_name);
-    // cpack settings
-    cmakelist << "# cpack settings, edit the following to pack up as you desire\n";
-    cmakelist << "if(UNIX)\n"
-              << "    set(CPACK_GENERATOR \"TGZ\")\n"
-              << "else()\n"
-              << "    set(CPACK_GENERATOR \"ZIP\")\n"
-              << "endif()\n"
-              << "set(CPACK_PACKAGE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/packages)\n"
-              << "include(CPack)\n";
-    INFO("root CMakeLists.txt written complete!");
-}
-
-void WriteUnitTests()
-{
-    std::ofstream unit_test("unit_test/CMakeLists.txt");
-    unit_test << R"(set(LIBRARIES_FOR_TEST "") # put your library here
-# an easy way to add unit test
-# for now it supports only one src file as SOURCE
-function(add_unit_test CASE_TARGET SOURCE)
-    add_executable(${CASE_TARGET} ${SOURCE})
-    target_link_libraries(${CASE_TARGET} PRIVATE )";
-    unit_test << (RepoType::EXECUTABLE != repo_type ? repo_name : "") << R"(
-    ${LIBRARIES_FOR_TEST} GTest::gtest GTest::gtest_main Threads::Threads)
-    string(TOUPPER ${CASE_TARGET} CASE_TARGET_UPPERCASE)
-    set(CASE_NAME "TEST_${CASE_TARGET_UPPERCASE}")
-    add_test(NAME ${CASE_NAME} COMMAND ${CASE_TARGET})
-endfunction()
-
-file(GLOB UNIT_TEST_SRCS "*.cpp")
-
-foreach(TEST_SRC ${UNIT_TEST_SRCS})
-    get_filename_component(BASE_NAME ${TEST_SRC} NAME_WE)
-    add_unit_test(${BASE_NAME} ${TEST_SRC})
-endforeach()
-)";
-
-    std::ofstream unit_test_example("unit_test/example.cpp");
-    unit_test_example << R"(#include <gtest/gtest.h>
-TEST(EXAMPLE, example_case)
-{
-    int i = 1;
-    EXPECT_EQ(i, 1);
-    bool no = false;
-    EXPECT_FALSE(no);
-}
-
-int main(int argc, char** argv)
-{
-    ::testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
-}
-)";
-
-    INFO("unit_test/CMakeLists.txt written complete!");
-}
-
-void WriteBenchmark()
-{
-    std::ofstream bench("bench/CMakeLists.txt");
-    bench << R"(set(LIBRARIES_FOR_BENCH "") # put your library here
-function(add_benchmark BENCH_NAME SOURCE)
-    add_executable(${BENCH_NAME} ${SOURCE})
-    target_link_libraries(${BENCH_NAME} PRIVATE )";
-    bench << (RepoType::EXECUTABLE != repo_type ? repo_name : "") << R"(
-    ${LIBRARIES_FOR_BENCH} benchmark Threads::Threads)
-endfunction()
-
-add_benchmark(bench_example bench_example.cpp)
-)";
-    std::ofstream bench_example("bench/bench_example.cpp");
-    bench_example << R"(#include <benchmark/benchmark.h>
-static bool isPrime(int n)
-{
-    if (n < 2)
-    {
-        return false;
-    }
-    for (int i = 2; i * i <= n; ++i)
-    {
-        if (n % i == 0)
-        {
-            return false;
-        }
-    }
-    return true;
-}
-
-static int findPrimes(int n)
-{
-    int count = 0;
-    for (int i = 2; i <= n; ++i)
-    {
-        if (isPrime(i))
-        {
-            count++;
-        }
-    }
-    return count;
-}
-
-static void BM_findPrimes(benchmark::State &state)
-{
-    for (auto _ : state)
-    {
-        int n = state.range(0);
-        int count = findPrimes(n);
-        benchmark::DoNotOptimize(count);
-    }
-}
-
-BENCHMARK(BM_findPrimes)->Range(1, 100000);
-BENCHMARK_MAIN();
-)";
-    INFO("benchmark example written complete!");
-}
-
-void WriteSrcAndHeader()
-{
-
-    // src file and header
-    // library repo's library.cpp will be located in 'src' dir
-    // executable repo's library.cpp will be located in 'repo_name' dir
-    auto cppfile_name =
-        fmt::format("{}/library.cpp", repo_type == RepoType::EXECUTABLE ? repo_name : "src");
-    std::ofstream cppfile(cppfile_name);
-    if (!cppfile)
-    {
-        ERROR("failed to open file: {}", cppfile_name);
-    }
-    cppfile << fmt::format(R"(#include "header.h"
-const char *GetVersionString()
-{{
-#define XX(x) #x
-#define STRINGIFY(x) XX(x)
-    return STRINGIFY({0}_VERSION_MAJOR.{0}_VERSION_MINOR.{0}_VERSION_PATCH);
-#undef XX
-#undef STRINGIFY
-}}
-)",
-        upper_name);
-
-    INFO("{} written complete!", cppfile_name);
-
-    if (RepoType::EXECUTABLE == repo_type)
-    {
-        std::ofstream helloworld(fmt::format("{}/main.cpp", repo_name));
-        if (!helloworld)
-        {
-            ERROR("failed to open file: {}/main.cpp", repo_name);
-        }
-        helloworld << "#include <iostream>\n"
-                   << "#include \"header.h\"\n\n"
-                   << "int main(int argc, char** argv)\n{\n"
-                   << fmt::format("    std::cout << \"hello {}! version:\"<< GetVersionString() << "
-                                  "std::endl;\n}}\n",
-                          repo_name);
-    }
-
-    // headers are always under the 'repo_name' dir
-    auto header_name = fmt::format("{}/header.h", repo_name);
-    std::ofstream header(header_name);
-    if (!header)
-    {
-        ERROR("failed to open file: {}", header_name);
-    }
-    header << fmt::format(
-        R"(#pragma once
-#define {0}_VERSION_MAJOR 0
-#define {0}_VERSION_MINOR 0
-#define {0}_VERSION_PATCH 1
-const char* GetVersionString();
-)",
-        upper_name);
-
-    INFO("{} written complete!", header_name);
 }

--- a/cmaker/functions.cpp
+++ b/cmaker/functions.cpp
@@ -17,7 +17,7 @@ bool CreateDirIfNotExist(std::string name)
         LOGERR("directory {} already exists!", name);
         return false;
     }
-    std::error_code ec;
+    error_code ec;
     if (!fs::create_directories(name, ec))
     {
         LOGERR("directory {} create failed! reason: {}", name, ec.message());

--- a/cmaker/functions.cpp
+++ b/cmaker/functions.cpp
@@ -14,16 +14,16 @@ bool CreateDirIfNotExist(std::string name)
 {
     if (fs::exists(name))
     {
-        ERROR("directory {} already exists!", name);
+        LOGERR("directory {} already exists!", name);
         return false;
     }
     std::error_code ec;
     if (!fs::create_directories(name, ec))
     {
-        ERROR("directory {} create failed! reason: {}", name, ec.message());
+        LOGERR("directory {} create failed! reason: {}", name, ec.message());
         return false;
     }
-    INFO("directory {} created!", name);
+    LOGINFO("directory {} created!", name);
     return true;
 }
 

--- a/cmaker/functions.cpp
+++ b/cmaker/functions.cpp
@@ -84,7 +84,8 @@ THE SOFTWARE.
 void PrintUsageAndQuit(po::options_description &desc, int errc)
 {
     std::cout << std::endl << desc << std::endl;
-    std::cout << GetLicense() << '\n';
+    if (errc == 0)
+        std::cout << GetLicense() << '\n';
     exit(errc);
 }
 

--- a/cmaker/functions.h
+++ b/cmaker/functions.h
@@ -22,9 +22,9 @@ namespace po = boost::program_options;
 
 void PrintUsageAndQuit(po::options_description &des, int errc = 1);
 
-#define INFO(xx, ...) fmt::print("[" GREEN("INFO") "] " xx "\n", ##__VA_ARGS__)
-#define WARN(xx, ...) fmt::print("[" YELLOW("WARN") "] " xx "\n", ##__VA_ARGS__)
-#define ERROR(xx, ...)                                                                             \
+#define LOGINFO(xx, ...) fmt::print("[" GREEN("INFO") "] " xx "\n", ##__VA_ARGS__)
+#define LOGWARN(xx, ...) fmt::print("[" YELLOW("WARN") "] " xx "\n", ##__VA_ARGS__)
+#define LOGERR(xx, ...)                                                                             \
     do                                                                                             \
     {                                                                                              \
         fmt::print(stderr, "[" RED("ERROR") "] " xx "\n", ##__VA_ARGS__);                          \
@@ -76,10 +76,10 @@ struct PushD
         fs::current_path(target, ec);
         if (ec)
         {
-            ERROR("pushd to {} error, reason: {}", target.string(), ec.message());
+            LOGERR("pushd to {} error, reason: {}", target.string(), ec.message());
             exit(1);
         }
-        INFO("entering directory {}", target.string());
+        LOGINFO("entering directory {}", target.string());
     }
     ~PushD()
     {
@@ -87,9 +87,9 @@ struct PushD
         fs::current_path(cwd, ec);
         if (ec)
         {
-            ERROR("popd to {} error, reason: {}", cwd.string(), ec.message());
+            LOGERR("popd to {} error, reason: {}", cwd.string(), ec.message());
         }
-        INFO("leaving directory {}", target.string());
+        LOGINFO("leaving directory {}", target.string());
     }
 
     fs::path cwd;

--- a/cmaker/functions.h
+++ b/cmaker/functions.h
@@ -4,13 +4,21 @@
 #include <iostream>
 #include <fstream>
 #include <string>
+
+#ifdef USE_BOOST_FILESYSTEM
+#include <boost/filesystem.hpp>
+namespace fs = boost::filesystem;
+using error_code = boost::system::error_code;
+#else
 #include <filesystem>
 namespace fs = std::filesystem;
+using error_code = std::error_code;
+#endif
 namespace po = boost::program_options;
 
 #define CMAKER_VERSION_MAJOR 0
 #define CMAKER_VERSION_MINOR 0
-#define CMAKER_VERSION_PATCH 2
+#define CMAKER_VERSION_PATCH 3
 
 #define COLORED(xx, id) "\033[1;" #id "m" xx "\033[0m"
 #define RED(xx) COLORED(xx, 31)
@@ -72,7 +80,7 @@ struct PushD
         : cwd(fs::current_path())
         , target(name)
     {
-        std::error_code ec;
+        error_code ec;
         fs::current_path(target, ec);
         if (ec)
         {
@@ -83,7 +91,7 @@ struct PushD
     }
     ~PushD()
     {
-        std::error_code ec;
+        error_code ec;
         fs::current_path(cwd, ec);
         if (ec)
         {

--- a/cmaker/writer_funcs.cpp
+++ b/cmaker/writer_funcs.cpp
@@ -1,0 +1,910 @@
+#include "writer_funcs.h"
+#include <fmt/format.h>
+
+void WriteCMakeLists(WriterContext const &ctx)
+{
+    auto upper_name = ToUpper(ctx.repo_name);
+    std::ofstream cmakelist("CMakeLists.txt");
+    cmakelist << "cmake_minimum_required(VERSION 3.21)\n\n"
+              << fmt::format(R"(set({0}_VERSION_MAJOR 0)
+set({0}_VERSION_MINOR 0)
+set({0}_VERSION_PATCH 1)
+project({1} 
+    LANGUAGES CXX C 
+    VERSION ${{{0}_VERSION_MAJOR}}.${{{0}_VERSION_MINOR}}.${{{0}_VERSION_PATCH}})
+)",
+                     upper_name, ctx.repo_name);
+    cmakelist << fmt::format(R"(configure_file({0}/header.h.in
+${{CMAKE_CURRENT_SOURCE_DIR}}/{0}/header.h @ONLY)
+)",
+        ctx.repo_name);
+
+    cmakelist << "# edit the following settings as you desire\n"
+              << fmt::format("set(CMAKE_CXX_STANDARD {})\n", ctx.cxx_std)
+              << "set(CMAKE_CXX_STANDARD_REQUIRED ON)\n"
+              << "set(CMAKE_CXX_STANDARD_EXTENSION OFF)\n"
+              << "add_compile_options(-Wfatal-errors)\n\n";
+    cmakelist << "# edit the following line to add your cmake modules\n"
+              << "list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake_modules)\n";
+    cmakelist << "# options flags to turn on/off unit tests and benchmarks\n"
+              << "option(BUILD_TESTS \"build unit tests\" OFF)\n"
+              << "option(BUILD_BENCHMARKS \"build benchmark tests\" OFF)\n";
+    cmakelist << "# edit the following line to add your dependencies\n"
+              << "find_package(Threads REQUIRED)\n\n";
+    // for executable repo, scan the 'repo_name' dir to add all cpp files as it's SRCS
+    if (RepoType::EXECUTABLE == ctx.repo_type)
+    {
+        cmakelist << fmt::format("file(GLOB EXECUTABLE_SRC \"{}/*.cpp\")\n", ctx.repo_name)
+                  << "add_executable(${PROJECT_NAME} ${EXECUTABLE_SRC})\n";
+        cmakelist << "target_include_directories(${PROJECT_NAME} PRIVATE\n    "
+                  << fmt::format("${{PROJECT_SOURCE_DIR}}/{})\n\n", ctx.repo_name);
+    }
+    else // for library repo, scan the 'src' dir to add all cpp files as it's SRCS
+    {
+        cmakelist << fmt::format("file(GLOB LIBRARY_SRC \"{}/*.cpp\")\n", ctx.repo_name)
+                  << "add_library(${PROJECT_NAME} "
+                  << (ctx.repo_type == RepoType::SHARED ? "SHARED" : "STATIC")
+                  << " \"${LIBRARY_SRC}\")\n";
+        cmakelist << "# you may add more dependencies' header dir here\n";
+        cmakelist << "target_include_directories(${PROJECT_NAME}\n"
+                  << "    PUBLIC\n"
+                  << "        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/" << ctx.repo_name << ">\n"
+                  << "        $<INSTALL_INTERFACE:" << ctx.repo_name << ">\n"
+                  << "    PRIVATE\n"
+                  << "        ${PROJECT_SOURCE_DIR}/src)\n\n";
+    }
+
+    // link example
+    cmakelist << R"(# edit the following line to link your dependencies libraries
+target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+            Threads::Threads))";
+
+    // unit tests
+    cmakelist << R"(#if called with -DBUILD_TESTS the unit test targets will be enabled
+if(BUILD_TESTS)
+    find_package(GTest REQUIRED)
+    enable_testing()
+    add_subdirectory(unit_test)
+endif()
+)";
+
+    // benchmark tests
+    cmakelist << R"(#if called with -DBUILD_BENCHMARKS the benchmark target will be enabled
+if(BUILD_BENCHMARKS)
+    find_package(benchmark REQUIRED)
+    add_subdirectory(bench)
+endif()
+)";
+
+    // install
+    cmakelist << "# install settings\n";
+    cmakelist << "include(GNUInstallDirs)\n"
+              << "install(TARGETS ${PROJECT_NAME}\n"
+              << "    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}\n"
+              << "    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}\n"
+              << "    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}\n)\n";
+    // install public headers if it's library repo
+    if (RepoType::EXECUTABLE != ctx.repo_type)
+    {
+        cmakelist << "# install public headers\n";
+        cmakelist << "set(PUBLIC_HEADER_DIR ${PROJECT_SOURCE_DIR}/" << ctx.repo_name << ")\n"
+                  << "install(DIRECTORY ${PUBLIC_HEADER_DIR}\n"
+                  << "    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}\n"
+                  << "    FILES_MATCHING\n"
+                  << "        PATTERN \"*.h\"\n"
+                  << "        PATTERN \"*.hpp\"\n)\n";
+    }
+    // both library and executable repo support versioning
+    cmakelist
+        << "# auto versioning reads from header.h to get versionstring\n"
+        << fmt::format(
+               R"(message(STATUS "current {0} version: ${{{1}_VERSION_MAJOR}}.${{{1}_VERSION_MINOR}}.${{{1}_VERSION_PATCH}}")
+set(CPACK_PACKAGE_VERSION_MAJOR ${{{1}_VERSION_MAJOR}})
+set(CPACK_PACKAGE_VERSION_MINOR ${{{1}_VERSION_MINOR}})
+set(CPACK_PACKAGE_VERSION_PATCH ${{{1}_VERSION_PATCH}})
+)",
+               ctx.repo_name, upper_name);
+    // cpack settings
+    cmakelist << "# cpack settings, edit the following to pack up as you desire\n";
+    cmakelist << "if(UNIX)\n"
+              << "    set(CPACK_GENERATOR \"TGZ\")\n"
+              << "else()\n"
+              << "    set(CPACK_GENERATOR \"ZIP\")\n"
+              << "endif()\n"
+              << "set(CPACK_PACKAGE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/packages)\n"
+              << "include(CPack)\n";
+    LOGINFO("root CMakeLists.txt written complete!");
+}
+
+void WriteUnitTests(WriterContext const &ctx)
+{
+    std::ofstream unit_test("unit_test/CMakeLists.txt");
+    unit_test << R"(set(LIBRARIES_FOR_TEST "") # put your library here
+# an easy way to add unit test
+# for now it supports only one src file as SOURCE
+function(add_unit_test CASE_TARGET SOURCE)
+    add_executable(${CASE_TARGET} ${SOURCE})
+    target_link_libraries(${CASE_TARGET} PRIVATE )";
+    unit_test << (RepoType::EXECUTABLE != ctx.repo_type ? ctx.repo_name : "") << R"(
+    ${LIBRARIES_FOR_TEST} GTest::gtest GTest::gtest_main Threads::Threads)
+    string(TOUPPER ${CASE_TARGET} CASE_TARGET_UPPERCASE)
+    set(CASE_NAME "TEST_${CASE_TARGET_UPPERCASE}")
+    add_test(NAME ${CASE_NAME} COMMAND ${CASE_TARGET})
+endfunction()
+
+file(GLOB UNIT_TEST_SRCS "*.cpp")
+
+foreach(TEST_SRC ${UNIT_TEST_SRCS})
+    get_filename_component(BASE_NAME ${TEST_SRC} NAME_WE)
+    add_unit_test(${BASE_NAME} ${TEST_SRC})
+endforeach()
+)";
+
+    std::ofstream unit_test_example("unit_test/example.cpp");
+    unit_test_example << R"(#include <gtest/gtest.h>
+TEST(EXAMPLE, example_case)
+{
+    int i = 1;
+    EXPECT_EQ(i, 1);
+    bool no = false;
+    EXPECT_FALSE(no);
+}
+
+int main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}
+)";
+
+    LOGINFO("unit_test/CMakeLists.txt written complete!");
+}
+
+void WriteBenchmark(WriterContext const &ctx)
+{
+    std::ofstream bench("bench/CMakeLists.txt");
+    bench << R"(set(LIBRARIES_FOR_BENCH "") # put your library here
+function(add_benchmark BENCH_NAME SOURCE)
+    add_executable(${BENCH_NAME} ${SOURCE})
+    target_link_libraries(${BENCH_NAME} PRIVATE )";
+    bench << (RepoType::EXECUTABLE != ctx.repo_type ? ctx.repo_name : "") << R"(
+    ${LIBRARIES_FOR_BENCH} benchmark Threads::Threads)
+endfunction()
+
+add_benchmark(bench_example bench_example.cpp)
+)";
+    std::ofstream bench_example("bench/bench_example.cpp");
+    bench_example << R"(#include <benchmark/benchmark.h>
+static bool isPrime(int n)
+{
+    if (n < 2)
+    {
+        return false;
+    }
+    for (int i = 2; i * i <= n; ++i)
+    {
+        if (n % i == 0)
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+static int findPrimes(int n)
+{
+    int count = 0;
+    for (int i = 2; i <= n; ++i)
+    {
+        if (isPrime(i))
+        {
+            count++;
+        }
+    }
+    return count;
+}
+
+static void BM_findPrimes(benchmark::State &state)
+{
+    for (auto _ : state)
+    {
+        int n = state.range(0);
+        int count = findPrimes(n);
+        benchmark::DoNotOptimize(count);
+    }
+}
+
+BENCHMARK(BM_findPrimes)->Range(1, 100000);
+BENCHMARK_MAIN();
+)";
+    LOGINFO("benchmark example written complete!");
+}
+
+void WriteSrcAndHeader(WriterContext const &ctx)
+{
+    std::string upper_name = ToUpper(ctx.repo_name);
+    // src file and header
+    // library repo's repo_name.cpp will be located in 'repo_name' dir
+    auto cppfile_name = fmt::format("{0}/{0}.cpp", ctx.repo_name);
+    std::ofstream cppfile(cppfile_name);
+    if (!cppfile)
+    {
+        LOGERR("failed to open file: {}", cppfile_name);
+    }
+    cppfile << fmt::format(R"(#include "header.h"
+const char *GetVersionString()
+{{
+#define XX(x) #x
+#define STRINGIFY(x) XX(x)
+    return STRINGIFY({0}_VERSION_MAJOR.{0}_VERSION_MINOR.{0}_VERSION_PATCH);
+#undef XX
+#undef STRINGIFY
+}}
+)",
+        upper_name);
+
+    LOGINFO("{} written complete!", cppfile_name);
+
+    if (RepoType::EXECUTABLE == ctx.repo_type)
+    {
+        std::ofstream helloworld(fmt::format("{}/main.cpp", ctx.repo_name));
+        if (!helloworld)
+        {
+            LOGERR("failed to open file: {}/main.cpp", ctx.repo_name);
+        }
+        helloworld << "#include <iostream>\n"
+                   << "#include \"header.h\"\n\n"
+                   << "int main(int argc, char** argv)\n{\n"
+                   << fmt::format("    std::cout << \"hello {}! version:\"<< GetVersionString() << "
+                                  "std::endl;\n}}\n",
+                          ctx.repo_name);
+    }
+
+    // headers are always under the 'repo_name' dir
+    auto header_name = fmt::format("{}/header.h.in", ctx.repo_name);
+    std::ofstream header(header_name);
+    if (!header)
+    {
+        LOGERR("failed to open file: {}", header_name);
+    }
+    header << fmt::format(
+        R"(#pragma once
+#define {0}_VERSION_MAJOR @{0}_VERSION_MAJOR@
+#define {0}_VERSION_MINOR @{0}_VERSION_MINOR@
+#define {0}_VERSION_PATCH @{0}_VERSION_PATCH@
+const char* GetVersionString();
+)",
+        upper_name);
+
+    LOGINFO("{} written complete!", header_name);
+}
+
+void WriteGitignore()
+{
+    std::ofstream gitignore(".gitignore");
+    gitignore << R"(# compile outputs
+*.o
+*.obj
+*.ko
+*.so
+*.a
+*.exe
+*.out
+*.app
+
+# compile intermediate outputs
+*.d
+*.depend
+*.gcno
+*.gcda
+*.stackdump
+
+# Visual Studion Code dirs
+.vscode/
+
+# Python cache
+__pycache__/
+*.pyc
+
+# build related
+autom4te.cache/
+build/
+
+# binary output
+bin/
+
+# os related
+.DS_Store
+ehthumbs.db
+Thumbs.db)";
+}
+
+void WriteClangformat()
+{
+    std::ofstream clangformat(".clang-format");
+    clangformat << R"(---
+Language:        Cpp
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -4
+AlignAfterOpenBracket: DontAlign
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Right
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:     
+  AfterClass:      true
+  AfterControlStatement: true
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  false
+  AfterObjCDeclaration: true
+  AfterStruct:     true
+  AfterUnion:      true
+  BeforeCatch:     true
+  BeforeElse:      true
+  IndentBraces:    false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: true
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     100
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces:  false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:   
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeCategories: 
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        1
+IncludeIsMainRegex: '(Test)?$'
+IndentCaseLabels: false
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Right
+ReflowComments:  true
+SortIncludes:    false
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        8
+UseTab:          Never
+IndentPPDirectives: AfterHash
+...
+)";
+}
+
+const std::string license_MIT = R"(MIT License
+
+Copyright (c) <year> <example@email.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
+copies of the Software, and to permit persons to whom the Software is 
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.)";
+
+const std::string license_LGPLV3 = R"(                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.)";
+
+const std::string license_APACHE = R"(                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.)";
+
+const std::string license_BOOST = R"(Boost Software License - Version 1.0 - August 17th, 2003
+
+Permission is hereby granted, free of charge, to any person or organization
+obtaining a copy of the software and accompanying documentation covered by
+this license (the "Software") to use, reproduce, display, distribute,
+execute, and transmit the Software, and to prepare derivative works of the
+Software, and to permit third-parties to whom the Software is furnished to
+do so, all subject to the following:
+
+The copyright notices in the Software and this entire statement, including
+the above license grant, this restriction and the following disclaimer,
+must be included in all copies of the Software, in whole or in part, and
+all derivative works of the Software, unless such copies or derivative
+works are solely in the form of machine-executable object code generated by
+a source language processor.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT
+SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE
+FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+)";
+
+void WriteLicense(WriterContext const &ctx)
+{
+    std::ofstream license("LICENSE");
+    if (ctx.licence.empty())
+    {
+        license << license_MIT;
+    }
+    else if (ToUpper(ctx.licence) == "MIT")
+    {
+        license << license_MIT;
+    }
+    else if (ToUpper(ctx.licence) == "LGPLV3")
+    {
+        license << license_LGPLV3;
+    }
+    else if (ToUpper(ctx.licence) == "APACHE")
+    {
+        license << license_APACHE;
+    }
+    else if (ToUpper(ctx.licence) == "BOOST")
+    {
+        license << license_BOOST;
+    }
+    else
+    {
+        LOGWARN("unsupported license type: {}, use MIT license instead", ctx.licence);
+        license << license_MIT;
+    }
+}
+
+void WriteReadme(WriterContext const &ctx)
+{
+    std::ofstream readme("README.md");
+    readme << fmt::format("# {}\n", ctx.repo_name);
+    if (RepoType::EXECUTABLE == ctx.repo_type)
+    {
+        readme << "## Build\n"
+               << "```bash\n"
+               << "mkdir build && cd build\n"
+               << "cmake ..\n"
+               << "make\n"
+               << "```\n";
+    }
+    else
+    {
+        readme << "## Build\n"
+               << "```bash\n"
+               << "mkdir build && cd build\n"
+               << "cmake .. -DBUILD_TESTS=ON -DBUILD_BENCHMARKS=ON\n"
+               << "make\n"
+               << "make test\n"
+               << "make bench\n"
+               << "```\n";
+    }
+    readme << "## License\n"
+           << fmt::format("This project is licensed under the {} License - see the "
+                          "[LICENSE](LICENSE) file for details.\n",
+                  ctx.licence);
+}

--- a/cmaker/writer_funcs.h
+++ b/cmaker/writer_funcs.h
@@ -1,0 +1,27 @@
+#pragma once
+#include "functions.h"
+#include <fstream>
+
+enum class RepoType
+{
+    STATIC,
+    SHARED,
+    EXECUTABLE,
+};
+
+struct WriterContext
+{
+    std::string repo_name;
+    RepoType repo_type;
+    std::string cxx_std{"11"};
+    std::string licence;
+};
+
+void WriteCMakeLists(WriterContext const& ctx);
+void WriteUnitTests(WriterContext const& ctx);
+void WriteBenchmark(WriterContext const& ctx);
+void WriteSrcAndHeader(WriterContext const& ctx);
+void WriteGitignore();
+void WriteClangformat();
+void WriteLicense(WriterContext const& ctx);
+void WriteReadme(WriterContext const& ctx);

--- a/main.cpp
+++ b/main.cpp
@@ -46,12 +46,12 @@ int main(int argc, const char *argv[])
 
     if (!IsExecutableInPath("git"))
     {
-        ERROR("cmaker requires " GREEN("git") " to create repo!");
+        LOGERR("cmaker requires " GREEN("git") " to create repo!");
     }
 
     if (!IsExecutableInPath("cmake"))
     {
-        ERROR("cmaker requires " GREEN("cmake") " on your system!");
+        LOGERR("cmaker requires " GREEN("cmake") " on your system!");
     }
 
     try
@@ -70,7 +70,7 @@ int main(int argc, const char *argv[])
     }
     catch (std::exception const &e)
     {
-        ERROR("error: {}\n", e.what());
+        LOGERR("error: {}\n", e.what());
     }
 
     if (vm.count("operation"))
@@ -90,13 +90,13 @@ int main(int argc, const char *argv[])
         }
         else
         {
-            WARN("invalid operation: {}\n", op);
+            LOGWARN("invalid operation: {}\n", op);
             PrintUsageAndQuit(all, 1);
         }
     }
     else
     {
-        WARN("you didn't set any operation.");
+        LOGWARN("you didn't set any operation.");
         PrintUsageAndQuit(all, 1);
     }
     return 0;

--- a/main.cpp
+++ b/main.cpp
@@ -22,9 +22,15 @@ int main(int argc, const char *argv[])
 {
     // clang-format off
     general.add_options()("help", "print the help message")
-        ("operation", po::value<std::string>()->required(), "1st positional argument. supported operations: new, add-library, add-submodule")
-        ("name", po::value<std::string>()->required(), "2nd positional argument. operand for the operation")
+        ("operation", po::value<std::string>()->required(), 
+            "1st positional argument. supported operations: new, add-library, add-submodule")
+        ("name", po::value<std::string>()->required(), 
+            "2nd positional argument. operand for the operation")
         ("version,v", "print the version string")
+        ("std", po::value<std::string>()->default_value("11"),
+            "c++ standard version, default value is: 11")
+        ("license", po::value<std::string>()->default_value("MIT"), 
+            "license type, default value is: MIT, supported values: MIT, Apache, LGPLv3, Boost")
         ;
     
     creator.add_options()("static", "create a repo template based on library project (static library) [default]")

--- a/unit_test/CMakeLists.txt
+++ b/unit_test/CMakeLists.txt
@@ -5,10 +5,19 @@ add_executable(test_functions
 target_include_directories(test_functions PRIVATE
     ${PROJECT_SOURCE_DIR}/cmaker)
 
-target_link_libraries(test_functions PRIVATE
-    Boost::program_options
-    fmt
-    GTest::gtest GTest::gtest_main
-    Threads::Threads)
+    if(NOT CXX17_SUPPORTED)
+    target_link_libraries(test_functions PRIVATE
+        Boost::program_options
+        Boost::filesystem
+        fmt
+        GTest::gtest GTest::gtest_main
+        Threads::Threads)
+else()
+    target_link_libraries(test_functions PRIVATE
+        Boost::program_options
+        fmt
+        GTest::gtest GTest::gtest_main
+        Threads::Threads)
+endif()
 
 add_test(NAME CMAKER_FUNCTIONS COMMAND test_functions)


### PR DESCRIPTION
- compatible with C++11 compilers (Boost.Filesystem required on C++11)
- move the `Write_` functions into `writer_funcs.h/cpp`
- added `Writer_` functions to generate `.gitignore`, `.clang-format`, `LICENSE` and `README.md` files.
- added `--std` options for specifying the `CMAKE_CXX_STANDARD` parameter in the generated CMakeLists.txt;
- added `--license` options for specifying the LICENSE file to be generated for the new project. Available licenses: MIT (default), LGPLv3, Boost, APACHE.
- updated README.md to comply with the changes.
